### PR TITLE
Improve system info display and add Docker status card

### DIFF
--- a/packages/core/src/application/get_system_info.rs
+++ b/packages/core/src/application/get_system_info.rs
@@ -2,22 +2,24 @@ use crate::domain::system_info::{DiskInfo, MemoryInfo, ProcessorInfo, StorageInf
 use eyre::Result;
 use sysinfo::{Disks, System};
 
-fn format_bytes(bytes: u64) -> String {
+// Formats bytes using decimal multiples (B, KB, MB, GB, TB)
+fn format_bytes_decimal(bytes: u64) -> String {
     let units = ["B", "KB", "MB", "GB", "TB"];
     let mut value = bytes as f64;
     let mut unit_index = 0;
 
-    let binary_to_decimal = |bytes: f64, power: i32| -> f64 {
-        bytes * (1024.0_f64.powi(power) / 1000.0_f64.powi(power))
-    };
-
-    while value >= 1024.0 && unit_index < units.len() - 1 {
-        value = binary_to_decimal(value, 1);
+    while value >= 1000.0 && unit_index < units.len() - 1 {
         value /= 1000.0;
         unit_index += 1;
     }
 
     format!("{:.2} {}", value, units[unit_index])
+}
+
+// Formats memory as whole-number GB (binary-based), e.g., "32 GB"
+fn format_memory_gb(bytes: u64) -> String {
+    let gb = (bytes as f64 / 1024f64.powi(3)).round() as u64;
+    format!("{} GB", gb)
 }
 
 pub fn get_system_info() -> Result<SystemInfo> {
@@ -57,7 +59,8 @@ fn get_memory_info(system: &System) -> MemoryInfo {
     let total = system.total_memory();
     MemoryInfo {
         total_bytes: total,
-        total_display: format_bytes(total),
+        // Show whole-number GB for user-friendly RAM display
+        total_display: format_memory_gb(total),
     }
 }
 
@@ -85,8 +88,10 @@ fn get_storage_info() -> Result<StorageInfo> {
                 mount_point: disk.mount_point().to_str()?.to_string(),
                 total_bytes: disk.total_space(),
                 available_bytes: disk.available_space(),
-                total_display: format_bytes(disk.total_space()),
-                available_display: format_bytes(disk.available_space()),
+                // For disks, users expect decimal-based sizes like Finder/Windows
+                total_display: format_bytes_decimal(disk.total_space()),
+                used_display: format_bytes_decimal(disk.total_space() - disk.available_space()),
+                available_display: format_bytes_decimal(disk.available_space()),
                 disk_type: disk.file_system().to_str()?.to_string(),
             })
         })
@@ -97,4 +102,25 @@ fn get_storage_info() -> Result<StorageInfo> {
     }
 
     Ok(StorageInfo { disks: disk_infos })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_binary_formats_expected() {
+        // 32 GiB in bytes
+        let bytes_32_gib = 32u64 * 1024 * 1024 * 1024;
+        let s = format_memory_gb(bytes_32_gib);
+        assert_eq!(s, "32 GB", "got {s}");
+    }
+
+    #[test]
+    fn decimal_formats_expected() {
+        // 32 GiB in bytes should be ~34.36 GB in decimal
+        let bytes_32_gib = 32u64 * 1024 * 1024 * 1024;
+        let s = format_bytes_decimal(bytes_32_gib);
+        assert!(s.starts_with("34.36 GB"), "got {s}");
+    }
 }

--- a/packages/core/src/domain/system_info.rs
+++ b/packages/core/src/domain/system_info.rs
@@ -33,6 +33,7 @@ pub struct DiskInfo {
     pub total_bytes: u64,
     pub available_bytes: u64,
     pub total_display: String,
+    pub used_display: String,
     pub available_display: String,
     pub disk_type: String,
 }

--- a/packages/gui/src/lib/components/DockerStatusCard.svelte
+++ b/packages/gui/src/lib/components/DockerStatusCard.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import * as Card from "$lib/components/ui/card";
+import { dockerStatus } from "$stores/dockerStatus.svelte";
+import { CheckCircle2, AlertCircle, Server } from "@lucide/svelte";
+
+export let showServerIcon: boolean = false;
+</script>
+
+<Card.Root>
+  <Card.Header class="pb-3">
+    <Card.Title class="text-sm font-medium flex items-center justify-between">
+      Docker Status
+      {#if showServerIcon}
+        <Server class="h-4 w-4 text-muted-foreground" />
+      {/if}
+    </Card.Title>
+  </Card.Header>
+  <Card.Content>
+    <div class="flex items-center space-x-2">
+      {#if dockerStatus.isRunning}
+        <CheckCircle2 class="h-4 w-4 text-green-500" />
+        <span class="text-sm font-medium">Running</span>
+      {:else}
+        <AlertCircle class="h-4 w-4 text-yellow-500" />
+        <span class="text-sm font-medium">Not Running</span>
+      {/if}
+    </div>
+  </Card.Content>
+</Card.Root>
+

--- a/packages/gui/src/lib/types/system_info.ts
+++ b/packages/gui/src/lib/types/system_info.ts
@@ -26,6 +26,7 @@ export interface DiskInfo {
   total_bytes: number;
   available_bytes: number;
   total_display: string;
+  used_display: string;
   available_display: string;
   disk_type: string;
 }

--- a/packages/gui/src/routes/Home.svelte
+++ b/packages/gui/src/routes/Home.svelte
@@ -7,16 +7,14 @@ import { serverUrlStore } from "$stores/serverUrl.svelte";
 import { systemInfoStore } from "$stores/systemInfo.svelte";
 import { packagesStore } from "$stores/packages.svelte";
 import { dockerStatus } from "$stores/dockerStatus.svelte";
+import DockerStatusCard from "$lib/components/DockerStatusCard.svelte";
 import { goto } from "$app/navigation";
 import { usePackageInstaller } from "$lib/composables/usePackageInstaller.svelte";
 import {
   Package2,
   Settings2,
-  CheckCircle2,
-  AlertCircle,
   Info,
   Activity,
-  Server,
   HardDrive,
   Cpu,
   ArrowRight,
@@ -61,25 +59,7 @@ onDestroy(() => {
   </div>
 
   <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-    <Card.Root>
-      <Card.Header class="pb-3">
-        <Card.Title class="text-sm font-medium flex items-center justify-between">
-          Docker Status
-          <Server class="h-4 w-4 text-muted-foreground" />
-        </Card.Title>
-      </Card.Header>
-      <Card.Content>
-        <div class="flex items-center space-x-2">
-          {#if dockerStatus.isRunning}
-            <CheckCircle2 class="h-4 w-4 text-green-500" />
-            <span class="text-sm font-medium">Running</span>
-          {:else}
-            <AlertCircle class="h-4 w-4 text-yellow-500" />
-            <span class="text-sm font-medium">Not Running</span>
-          {/if}
-        </div>
-      </Card.Content>
-    </Card.Root>
+    <DockerStatusCard showServerIcon={true} />
 
     <Card.Root>
       <Card.Header class="pb-3">
@@ -168,7 +148,7 @@ onDestroy(() => {
                 class="w-full"
               >
                 <Settings2 class="h-4 w-4 mr-1" />
-                Manage Node
+                Manage
               </Button>
             </Card.Footer>
           </Card.Root>

--- a/packages/gui/src/routes/packages/+page.svelte
+++ b/packages/gui/src/routes/packages/+page.svelte
@@ -110,7 +110,7 @@ onMount(() => {
             {#if isInstalled}
               <Button 
                 size="sm"
-                variant="outline"
+                variant="default"
                 onclick={() => managePackage(name)}
                 class="w-full"
               >

--- a/packages/gui/src/routes/system-info/+page.svelte
+++ b/packages/gui/src/routes/system-info/+page.svelte
@@ -7,6 +7,7 @@ import { Skeleton } from "$lib/components/ui/skeleton";
 import { Progress } from "$lib/components/ui/progress";
 import * as Card from "$lib/components/ui/card";
 import { Button } from "$lib/components/ui/button";
+import DockerStatusCard from "$lib/components/DockerStatusCard.svelte";
 import {
   Cpu,
   HardDrive,
@@ -14,8 +15,6 @@ import {
   Server,
   WifiOff,
   RefreshCw,
-  CheckCircle2,
-  AlertCircle,
   Globe,
 } from "@lucide/svelte";
 
@@ -27,11 +26,7 @@ function fetchSystemInfo() {
   systemInfoStore.fetchSystemInfo();
 }
 
-const getUsageColor = (percentage: number) => {
-  if (percentage < 50) return "text-green-500";
-  if (percentage < 80) return "text-yellow-500";
-  return "text-red-500";
-};
+// Progress bar alone conveys usage; no percentage text needed.
 
 onMount(() => {
   if (!systemInfoStore.systemInfo) {
@@ -65,22 +60,7 @@ onMount(() => {
 
   <!-- Status Cards -->
   <div class="grid gap-4 md:grid-cols-3">
-    <Card.Root>
-      <Card.Header class="pb-3">
-        <Card.Title class="text-sm font-medium">Docker Status</Card.Title>
-      </Card.Header>
-      <Card.Content>
-        <div class="flex items-center space-x-2">
-          {#if dockerStatus.isRunning}
-            <CheckCircle2 class="h-4 w-4 text-green-500" />
-            <span class="text-sm font-medium">Running</span>
-          {:else}
-            <AlertCircle class="h-4 w-4 text-yellow-500" />
-            <span class="text-sm font-medium">Not Running</span>
-          {/if}
-        </div>
-      </Card.Content>
-    </Card.Root>
+    <DockerStatusCard />
 
     <Card.Root>
       <Card.Header class="pb-3">
@@ -185,16 +165,11 @@ onMount(() => {
             <div class="flex items-center justify-between">
               <div>
                 <p class="text-sm font-medium">{disk.name}</p>
-                <p class="text-xs text-muted-foreground">{disk.mount_point} • {disk.disk_type}</p>
               </div>
-              <span class="text-sm font-medium {getUsageColor(usagePercent)}">
-                {usagePercent}%
-              </span>
             </div>
             <Progress value={usagePercent} max={100} />
             <div class="flex justify-between text-xs text-muted-foreground">
-              <span>{disk.available_display} free</span>
-              <span>{disk.total_display} total</span>
+              <span>{disk.used_display} of {disk.total_display} used</span>
             </div>
           </div>
         {/each}


### PR DESCRIPTION
This PR polishes system information formatting and consolidates Docker status UI.\n\nChanges\n- Memory: display RAM as whole-number GB for readability (e.g., "32 GB").\n- Storage: use decimal units for disk sizes to align with Finder/Windows; add `used_display`.\n- Rust: add focused tests for decimal and memory formatting; remove unused helper.\n- GUI: add reusable `DockerStatusCard` and use it in Home and System Info.\n- GUI: tweak "Manage" button variant in Packages.\n\nNotes\n- Unit + integration tests pass locally (`just test`).\n- TypeScript types updated to include `used_display`.