### PR TITLE
Add download page with platform icons

### DIFF
--- a/website/src/lib/components/icons/Linux.svelte
+++ b/website/src/lib/components/icons/Linux.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+let { class: className = "", ...rest } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  {...rest}
+>
+  <path d="M12 3c2 0 3 1 3 3v2a4 4 0 0 1 2 3v5a3 3 0 0 1-3 3h-4a3 3 0 0 1-3-3v-5a4 4 0 0 1 2-3V6c0-2 1-3 3-3Z" />
+  <path d="M8 13c-1 0-2 .5-2 2s1 2 2 2" />
+  <path d="M16 13c1 0 2 .5 2 2s-1 2-2 2" />
+</svg>

--- a/website/src/lib/components/icons/Windows.svelte
+++ b/website/src/lib/components/icons/Windows.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+let { class: className = "", ...rest } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  class={className}
+  {...rest}
+>
+  <path d="M3 5L11 4v7H3zM13 3l8-1v9h-8zM3 13h8v7l-8-1zM13 13h8v8l-8-1z" />
+</svg>

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -14,10 +14,10 @@ import { Button } from "$lib/components/ui/button/index.js";
 			</p>
 			<img src="/black-kitty.gif" alt="Black Kitty" class="nyan-cat mt-12" />
 			<div class="mt-8 flex flex-col items-center gap-4">
-				<Button href="https://github.com/blackkittylabs/kittynode/releases" size="lg" class="gap-2">
-					<Download class="h-5 w-5" />
-					Download now
-				</Button>
+                                <Button href="/download" size="lg" class="gap-2">
+                                        <Download class="h-5 w-5" />
+                                        Download now
+                                </Button>
 				<p class="text-sm text-muted-foreground">
 					Available for macOS, Linux, and Windows
 				</p>

--- a/website/src/routes/download/+page.svelte
+++ b/website/src/routes/download/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { Button } from "$lib/components/ui/button/index.js";
+import { Apple } from "@lucide/svelte";
+import Windows from "$lib/components/icons/Windows.svelte";
+import Linux from "$lib/components/icons/Linux.svelte";
+</script>
+
+<div class="container mx-auto px-4 py-16">
+  <div class="mx-auto flex max-w-md flex-col items-center text-center">
+    <picture>
+      <source type="image/webp" srcset="/kittynode-logo-app-160.webp" />
+      <img
+        src="/kittynode-logo-app-160.png"
+        alt="Kittynode logo"
+        class="mb-8 h-20 w-20"
+        width="80"
+        height="80"
+        decoding="async"
+      />
+    </picture>
+    <h1 class="text-3xl font-medium">Download Kittynode</h1>
+    <p class="mt-2 text-sm text-muted-foreground">Version 0.0.0</p>
+  </div>
+
+  <div class="mx-auto mt-12 grid max-w-4xl gap-6 sm:grid-cols-3">
+    <div class="flex flex-col items-center rounded-lg border p-6 text-center">
+      <Apple class="mb-4 h-12 w-12" />
+      <Button href="#" class="w-full">Download for macOS</Button>
+    </div>
+    <div class="flex flex-col items-center rounded-lg border p-6 text-center">
+      <Windows class="mb-4 h-12 w-12" />
+      <Button href="#" class="w-full">Download for Windows</Button>
+    </div>
+    <div class="flex flex-col items-center rounded-lg border p-6 text-center">
+      <Linux class="mb-4 h-12 w-12" />
+      <Button href="#" class="w-full">Download for Linux</Button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add first-party download page mirroring zed.dev layout
- introduce custom Windows and Linux icons alongside existing Apple icon
- link homepage download button to new page

## Testing
- `npm run format-lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4bef2e8888330a3639b6babcb68e7