### PR TITLE
Fix flaky window visibility on app startup

### DIFF
--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use kittynode_core::domain::package::{Package, PackageConfig};
 use kittynode_core::domain::system_info::SystemInfo;
 use std::collections::HashMap;
 use std::sync::LazyLock;
+use tauri::Manager;
 use tauri_plugin_http::reqwest;
 use tracing::info;
 

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -339,6 +339,14 @@ pub fn run() -> Result<()> {
     let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
 
     builder
+        .setup(|app| {
+            // Ensure window is shown on startup to fix flaky visibility
+            if let Some(window) = app.get_webview_window("main") {
+                window.show().ok();
+                window.set_focus().ok();
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             get_packages,
             get_installed_packages,

--- a/packages/gui/src-tauri/tauri.conf.json
+++ b/packages/gui/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
     "windows": [
       {
         "title": "",
-        "visible": false,
+        "visible": true,
         "height": 900,
         "width": 1200
       }


### PR DESCRIPTION
## Summary
Adds explicit window show and focus on app startup to fix flaky window visibility issues, particularly on macOS.

## Problem
Sometimes the app window doesn't appear properly on startup or after restart, requiring users to manually find and focus the window.

## Solution
- Added a `setup` hook in Rust that explicitly shows and focuses the main window on app startup
- Changed window `visible` setting from `false` to `true` in tauri.conf.json
- The setup hook ensures the window is always shown even if there are platform-specific quirks

## Test Plan
- [ ] Launch the app normally - window should appear immediately
- [ ] Test app restart functionality - window should reappear after restart
- [ ] Test on macOS specifically to verify the flakiness is resolved
- [ ] Verify no window flash or visual artifacts on startup

🤖 Generated with [Claude Code](https://claude.ai/code)