### PR TITLE
Update website version only after successful release

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -101,8 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
+          ref: main
           token: ${{ secrets.RELEASE_BOT_PAT }}
 
       - name: Update and commit version
@@ -118,5 +117,5 @@ jobs:
           else
             git add website/src/lib/release.json
             git commit -m "Update website version to $VERSION"
-            git push origin HEAD:main
+            git push
           fi

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -73,6 +73,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           generate_release_notes: true
 
       - name: Build the app
@@ -93,8 +94,20 @@ jobs:
           args: ${{ matrix.args }}
           includeUpdaterJson: true
 
-  update-website-version:
+  publish-release:
     needs: publish-tauri
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: false
+
+  update-website-version:
+    needs: publish-release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -73,7 +73,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          generate_release_notes: true
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0.5.23

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -92,3 +92,31 @@ jobs:
           projectPath: packages/app/src-tauri
           args: ${{ matrix.args }}
           includeUpdaterJson: true
+
+  update-website-version:
+    needs: publish-tauri
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_PAT }}
+
+      - name: Update and commit version
+        run: |
+          VERSION="${{ github.ref_name }}" && VERSION="${VERSION#kittynode-app@}"
+          printf '{\n  "version": "%s",\n  "date": "%s"\n}\n' "$VERSION" "$(date +"%B %-d, %Y")" > website/src/lib/release.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet website/src/lib/release.json; then
+            echo "No changes to commit"
+          else
+            git add website/src/lib/release.json
+            git commit -m "Update website version to $VERSION"
+            git push origin HEAD:main
+          fi

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -112,6 +112,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Requires RELEASE_BOT_PAT secret with Contents: Write permission
+      # to push past branch protection rules on main branch
       - uses: actions/checkout@v5
         with:
           ref: main
@@ -130,5 +132,8 @@ jobs:
           else
             git add website/src/lib/release.json
             git commit -m "Update website version to $VERSION"
+
+            # Pull latest changes before pushing to avoid non-fast-forward errors
+            git pull --rebase origin main
             git push
           fi

--- a/justfile
+++ b/justfile
@@ -75,8 +75,7 @@ lint-rs-pedantic:
 release:
   cargo set-version -p kittynode-tauri --bump minor
   cargo generate-lockfile
-  printf '{\n  "version": "%s",\n  "date": "%s"\n}\n' "$(cargo pkgid -p kittynode-tauri | cut -d@ -f2)" "$(date +"%B %-d, %Y")" > website/src/lib/release.json
-  git add packages/app/src-tauri/Cargo.toml Cargo.lock website/src/lib/release.json
+  git add packages/app/src-tauri/Cargo.toml Cargo.lock
   git commit -m "Release kittynode-app@$(cargo pkgid -p kittynode-tauri | cut -d@ -f2)"
   git tag "kittynode-app@$(cargo pkgid -p kittynode-tauri | cut -d@ -f2)" -m "Release kittynode-app@$(cargo pkgid -p kittynode-tauri | cut -d@ -f2)"
 


### PR DESCRIPTION
## Summary
- Website was updating version immediately when `just release` runs, before builds complete
- Now website only updates after all platform builds succeed in GitHub Actions
- Prevents showing new version if release pipeline fails

## Changes
- Remove website version update from justfile release task  
- Add `update-website-version` job to release-app.yaml workflow that runs after all builds
- Job checks out the release tag and pushes version update to main

## Requirements
- Requires `RELEASE_BOT_PAT` repository secret with Contents:Write permission to push past branch protection

## Test Plan
- [ ] Next release: Run `just release` and push tag
- [ ] Verify website doesn't update until all platform builds complete
- [ ] Verify website shows correct version after successful release