### PR TITLE
Add verified commits for github-actions bot

### DIFF
--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -112,28 +112,23 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Requires RELEASE_BOT_PAT secret with Contents: Write permission
-      # to push past branch protection rules on main branch
       - uses: actions/checkout@v5
         with:
           ref: main
-          token: ${{ secrets.RELEASE_BOT_PAT }}
+          # Use GITHUB_TOKEN for the checkout since verified-bot-commit will handle the push
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update and commit version
+      - name: Update version file
+        id: update_version
         run: |
           VERSION="${{ github.ref_name }}" && VERSION="${VERSION#kittynode-app@}"
           printf '{\n  "version": "%s",\n  "date": "%s"\n}\n' "$VERSION" "$(date +"%B %-d, %Y")" > website/src/lib/release.json
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if git diff --quiet website/src/lib/release.json; then
-            echo "No changes to commit"
-          else
-            git add website/src/lib/release.json
-            git commit -m "Update website version to $VERSION"
-
-            # Pull latest changes before pushing to avoid non-fast-forward errors
-            git pull --rebase origin main
-            git push
-          fi
+      - name: Commit changes with verified signature
+        uses: iarekylew00t/verified-bot-commit@v2
+        with:
+          token: ${{ secrets.RELEASE_BOT_PAT }}  # Use PAT to bypass branch protection
+          message: Update website version to ${{ steps.update_version.outputs.version }}
+          files: |
+            website/src/lib/release.json

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -113,22 +113,19 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: main
-          # Use GITHUB_TOKEN for the checkout since verified-bot-commit will handle the push
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version file
-        id: update_version
+        id: update
         run: |
-          VERSION="${{ github.ref_name }}" && VERSION="${VERSION#kittynode-app@}"
+          VERSION="${VERSION#kittynode-app@}"
           printf '{\n  "version": "%s",\n  "date": "%s"\n}\n' "$VERSION" "$(date +"%B %-d, %Y")" > website/src/lib/release.json
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ github.ref_name }}
 
-      - name: Commit changes with verified signature
+      - name: Commit changes
         uses: iarekylew00t/verified-bot-commit@v2
         with:
-          token: ${{ secrets.RELEASE_BOT_PAT }}  # Use PAT to bypass branch protection
-          message: Update website version to ${{ steps.update_version.outputs.version }}
-          files: |
-            website/src/lib/release.json
+          token: ${{ secrets.RELEASE_BOT_PAT }}  # Required to bypass branch protection
+          message: Update website version to ${{ steps.update.outputs.version }}
+          files: website/src/lib/release.json

--- a/.github/workflows/release-app.yaml
+++ b/.github/workflows/release-app.yaml
@@ -126,6 +126,7 @@ jobs:
       - name: Commit changes
         uses: iarekylew00t/verified-bot-commit@v2
         with:
+          ref: refs/heads/main  # Explicitly target main branch, not the tag
           token: ${{ secrets.RELEASE_BOT_PAT }}  # Required to bypass branch protection
           message: Update website version to ${{ steps.update.outputs.version }}
           files: website/src/lib/release.json


### PR DESCRIPTION
## Summary
- Switch from `stefanzweifel/git-auto-commit-action` to `iarekylew00t/verified-bot-commit@v2`
- Ensures commits from github-actions[bot] in the release workflow are verified with GitHub's GPG key
- Commits will display the green "Verified" badge in the GitHub UI

## Context
Previously, commits made by github-actions[bot] during the release process were unverified. This PR updates the release workflow to use an action that creates commits through the GitHub API, which automatically signs them with GitHub's key.

## Changes
- Updated the `update-website-version` job in `.github/workflows/release-app.yaml`
- Uses `iarekylew00t/verified-bot-commit@v2` action for creating verified commits
- Maintains the use of `RELEASE_BOT_PAT` to bypass branch protection rules

## Testing
The next release will demonstrate that the automated version update commit is properly verified.