### PR TITLE
Auto-start Docker Desktop on app launch

### DIFF
--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -63,21 +63,15 @@ async fn get_capabilities(server_url: String) -> Result<Vec<String>, String> {
             .await
             .map_err(|e| e.to_string())?;
 
-        let status = res.status();
-        let error_text = res.text().await.unwrap_or_default();
-
-        if !status.is_success() {
+        if !res.status().is_success() {
+            let status = res.status();
+            let error_text = res.text().await.unwrap_or_default();
             return Err(format!(
                 "Failed to get capabilities: {} - {}",
                 status, error_text
             ));
         }
 
-        let res = HTTP_CLIENT
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| e.to_string())?;
         res.json::<Vec<String>>().await.map_err(|e| e.to_string())
     } else {
         kittynode_core::application::get_capabilities().map_err(|e| e.to_string())

--- a/packages/app/src/lib/components/DockerStatusCard.svelte
+++ b/packages/app/src/lib/components/DockerStatusCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import * as Card from "$lib/components/ui/card";
 import { dockerStatus } from "$stores/dockerStatus.svelte";
-import { CircleCheck, CircleAlert, Server } from "@lucide/svelte";
+import { CircleCheck, CircleAlert, Server, Loader2 } from "@lucide/svelte";
 
 export let showServerIcon: boolean = false;
 </script>
@@ -17,7 +17,10 @@ export let showServerIcon: boolean = false;
   </Card.Header>
   <Card.Content>
     <div class="flex items-center space-x-2">
-      {#if dockerStatus.isRunning}
+      {#if dockerStatus.isStarting}
+        <Loader2 class="h-4 w-4 text-blue-500 animate-spin" />
+        <span class="text-sm font-medium">Starting Docker...</span>
+      {:else if dockerStatus.isRunning}
         <CircleCheck class="h-4 w-4 text-green-500" />
         <span class="text-sm font-medium">Running</span>
       {:else}

--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -37,6 +37,12 @@ function isMobileAndLocal() {
 
 onMount(async () => {
   if (!systemInfoStore.systemInfo) systemInfoStore.fetchSystemInfo();
+
+  // Start Docker if needed (only on first app startup)
+  if (!isMobileAndLocal()) {
+    await dockerStatus.startDockerIfNeeded();
+  }
+
   dockerStatus.startPolling();
 
   if (!isMobileAndLocal()) {

--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -40,10 +40,14 @@ onMount(async () => {
 
   // Start Docker if needed (only on first app startup)
   if (!isMobileAndLocal()) {
-    await dockerStatus.startDockerIfNeeded();
+    const result = await dockerStatus.startDockerIfNeeded();
+    // Only start polling if Docker wasn't just started (which already starts polling)
+    if (result !== "starting") {
+      dockerStatus.startPolling();
+    }
+  } else {
+    dockerStatus.startPolling();
   }
-
-  dockerStatus.startPolling();
 
   if (!isMobileAndLocal()) {
     await packagesStore.loadPackages();

--- a/packages/app/src/stores/dockerStatus.svelte.ts
+++ b/packages/app/src/stores/dockerStatus.svelte.ts
@@ -2,11 +2,21 @@ import { invoke } from "@tauri-apps/api/core";
 import { platform } from "@tauri-apps/plugin-os";
 
 let isRunning = $state<boolean | null>(null);
+let isStarting = $state<boolean>(false);
 let interval: number | null = $state(null);
+let wasAutoStarted = $state<boolean>(false);
 
 export const dockerStatus = {
   get isRunning() {
     return isRunning;
+  },
+
+  get isStarting() {
+    return isStarting;
+  },
+
+  get wasAutoStarted() {
+    return wasAutoStarted;
   },
 
   async checkDocker() {
@@ -14,9 +24,34 @@ export const dockerStatus = {
       isRunning = ["ios", "android"].includes(platform())
         ? true
         : await invoke("is_docker_running");
+
+      // If Docker is running and we were starting, clear the starting state
+      if (isRunning && isStarting) {
+        isStarting = false;
+      }
     } catch (e) {
       console.error(`Failed to check Docker status: ${e}`);
       isRunning = false;
+    }
+  },
+
+  async startDockerIfNeeded() {
+    try {
+      const result = await invoke<string>("start_docker_if_needed");
+
+      if (result === "starting") {
+        isStarting = true;
+        // Start more aggressive polling while Docker starts
+        this.startPolling(2000);
+      }
+
+      // Check if Docker was auto-started
+      wasAutoStarted = await invoke<boolean>("was_docker_auto_started");
+
+      return result;
+    } catch (e) {
+      console.error(`Failed to start Docker: ${e}`);
+      return "error";
     }
   },
 

--- a/packages/app/src/stores/dockerStatus.svelte.ts
+++ b/packages/app/src/stores/dockerStatus.svelte.ts
@@ -80,6 +80,10 @@ export const dockerStatus = {
   },
 
   startPolling(intervalMs = 5000) {
+    // Clear any existing interval before starting a new one
+    if (interval !== null) {
+      window.clearInterval(interval);
+    }
     this.checkDocker(); // Initial check
     interval = window.setInterval(() => this.checkDocker(), intervalMs);
   },

--- a/packages/core/src/application/mod.rs
+++ b/packages/core/src/application/mod.rs
@@ -13,6 +13,7 @@ pub mod install_package;
 pub mod is_docker_running;
 pub mod remove_capability;
 pub mod set_server_url;
+pub mod start_docker;
 pub mod update_package_config;
 
 pub use add_capability::add_capability;
@@ -30,4 +31,5 @@ pub use install_package::install_package;
 pub use is_docker_running::is_docker_running;
 pub use remove_capability::remove_capability;
 pub use set_server_url::set_server_url;
+pub use start_docker::start_docker;
 pub use update_package_config::update_package_config;

--- a/packages/core/src/application/start_docker.rs
+++ b/packages/core/src/application/start_docker.rs
@@ -1,0 +1,36 @@
+use eyre::Result;
+use std::process::Command;
+use tracing::info;
+
+pub async fn start_docker() -> Result<()> {
+    info!("Attempting to start Docker Desktop");
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").arg("-a").arg("Docker").spawn()?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Try systemctl first (for systemd-based distros)
+        if Command::new("systemctl")
+            .arg("--user")
+            .arg("start")
+            .arg("docker-desktop")
+            .spawn()
+            .is_err()
+        {
+            // Fallback to direct launch
+            Command::new("docker-desktop").spawn()?;
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("cmd")
+            .args(&["/C", "start", "", "Docker Desktop.exe"])
+            .spawn()?;
+    }
+
+    Ok(())
+}

--- a/packages/core/src/application/start_docker.rs
+++ b/packages/core/src/application/start_docker.rs
@@ -40,7 +40,7 @@ pub async fn start_docker() -> Result<()> {
         ];
 
         for (cmd, args) in attempts {
-            if let Ok(_) = Command::new(cmd).args(&args).spawn() {
+            if Command::new(cmd).args(&args).spawn().is_ok() {
                 info!("Started Docker Desktop using: {} {:?}", cmd, args);
                 started = true;
                 break;


### PR DESCRIPTION
## Summary
- Automatically starts Docker Desktop when Kittynode launches if not already running
- Shows "Starting Docker..." status in UI while Docker is launching
- Only auto-starts once per session - respects user choice if they quit Docker

## Implementation Details

### Platform Support
- **macOS**: Uses `open -a Docker` command
- **Linux**: Tries systemctl first, then falls back to direct launch
- **Windows**: Uses `cmd /C start "" "Docker Desktop.exe"`

### Key Features
- Minimal, robust implementation using platform-native commands
- Visual feedback with spinning loader during Docker startup
- Single startup per session - won't restart if user quits Docker
- Only runs on desktop platforms (skipped on iOS/Android)

### Changes
- Added `start_docker.rs` module in core for platform-specific Docker startup
- Enhanced Docker status store with `isStarting` state and auto-start logic
- Updated DockerStatusCard to show starting state with spinner
- Modified app startup flow to trigger Docker auto-start

## Test Plan
- [x] Tested on macOS - Docker starts automatically
- [ ] Test on Linux
- [ ] Test on Windows
- [x] Verify Docker only starts once per session
- [x] Verify UI shows "Starting Docker..." status
- [x] Verify app works normally if Docker startup fails

🤖 Generated with [Claude Code](https://claude.ai/code)