### PR TITLE
Prevent header logo resizing on narrow viewports

### DIFF
--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -81,11 +81,16 @@ let { children } = $props();
 		align-items: center;
 		gap: 0.375rem;
 		text-decoration: none;
+		flex-shrink: 0;
 	}
 
 	.app-logo {
 		height: 2.5rem;
 		width: 2.5rem;
+		min-height: 2.5rem;
+		min-width: 2.5rem;
+		max-width: none;
+		flex-shrink: 0;
 	}
 
 	.wordmark-text {


### PR DESCRIPTION
## Summary
- keep the header wordmark from shrinking inside the flex header
- pin the logo dimensions so it stays square even on ultra-narrow viewports

## Testing
- just lint-js-fix