### PR TITLE
Remove unused wasAutoStarted code

### DIFF
--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -165,11 +165,6 @@ async fn start_docker_if_needed() -> Result<String, String> {
 }
 
 #[tauri::command]
-fn was_docker_auto_started() -> bool {
-    *DOCKER_AUTO_STARTED.lock().unwrap()
-}
-
-#[tauri::command]
 async fn install_package(name: String, server_url: String) -> Result<(), String> {
     if !server_url.is_empty() {
         let url = format!("{}/install_package/{}", server_url, name);
@@ -386,7 +381,6 @@ pub fn run() -> Result<()> {
             get_installed_packages,
             is_docker_running,
             start_docker_if_needed,
-            was_docker_auto_started,
             install_package,
             delete_package,
             delete_kittynode,

--- a/packages/app/src/stores/dockerStatus.svelte.ts
+++ b/packages/app/src/stores/dockerStatus.svelte.ts
@@ -4,7 +4,6 @@ import { platform } from "@tauri-apps/plugin-os";
 let isRunning = $state<boolean | null>(null);
 let isStarting = $state<boolean>(false);
 let interval: number | null = $state(null);
-let wasAutoStarted = $state<boolean>(false);
 let startingTimeout: number | null = $state(null);
 
 export const dockerStatus = {
@@ -14,10 +13,6 @@ export const dockerStatus = {
 
   get isStarting() {
     return isStarting;
-  },
-
-  get wasAutoStarted() {
-    return wasAutoStarted;
   },
 
   async checkDocker() {
@@ -49,9 +44,6 @@ export const dockerStatus = {
         // Set a timeout to stop showing "starting" after 30 seconds
         this.setStartingTimeout(30000);
       }
-
-      // Check if Docker was auto-started
-      wasAutoStarted = await invoke<boolean>("was_docker_auto_started");
 
       return result;
     } catch (e) {


### PR DESCRIPTION
## Summary
- Removed unused `wasAutoStarted` state variable and getter from frontend dockerStatus store
- Removed unused `was_docker_auto_started` Tauri command from backend
- Preserved backend logic that prevents multiple Docker auto-start attempts within a session

## Context
The `wasAutoStarted` variable was being set but never consumed anywhere in the frontend, making it dead code. The backend still maintains the correct behavior where Docker only starts on initial app launch, not if the user quits Docker while the app is running.

## Test plan
- [ ] Verify Docker auto-starts on app launch when not running
- [ ] Verify Docker doesn't restart if user stops it while app is running
- [ ] Verify Docker restarts on app relaunch after being quit

🤖 Generated with [Claude Code](https://claude.ai/code)