### PR TITLE
Respect Docker shutdown and stabilize package status

### DIFF
--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tauri_plugin_http::reqwest;
 use tracing::info;
 
 pub static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+// Tracks whether we've already attempted to start Docker automatically this session
 pub static DOCKER_AUTO_STARTED: LazyLock<Arc<Mutex<bool>>> =
     LazyLock::new(|| Arc::new(Mutex::new(false)));
 
@@ -104,20 +105,14 @@ async fn get_installed_packages(server_url: String) -> Result<Vec<Package>, Stri
             .map_err(|e| e.to_string())?;
 
         let status = res.status();
-        let error_text = res.text().await.unwrap_or_default();
-
         if !status.is_success() {
+            let error_text = res.text().await.unwrap_or_default();
             return Err(format!(
                 "Failed to get installed packages: {} - {}",
                 status, error_text
             ));
         }
 
-        let res = HTTP_CLIENT
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| e.to_string())?;
         res.json::<Vec<Package>>().await.map_err(|e| e.to_string())
     } else {
         kittynode_core::application::get_installed_packages()
@@ -136,29 +131,32 @@ async fn is_docker_running() -> bool {
 async fn start_docker_if_needed() -> Result<String, String> {
     info!("Checking if Docker needs to be started");
 
-    // Check if we've already auto-started Docker this session
-    {
+    let already_auto_started = {
         let auto_started = DOCKER_AUTO_STARTED.lock().unwrap();
-        if *auto_started {
-            return Ok("already_started".to_string());
-        }
+        *auto_started
+    };
+    if already_auto_started {
+        return Ok("already_started".to_string());
     }
 
-    // Check if Docker is already running
     if kittynode_core::application::is_docker_running().await {
         return Ok("running".to_string());
     }
 
-    // Try to start Docker
-    info!("Starting Docker Desktop");
-    kittynode_core::application::start_docker()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Mark that we've auto-started Docker
     {
         let mut auto_started = DOCKER_AUTO_STARTED.lock().unwrap();
+        if *auto_started {
+            return Ok("already_started".to_string());
+        }
         *auto_started = true;
+    }
+
+    info!("Starting Docker Desktop");
+
+    if let Err(err) = kittynode_core::application::start_docker().await {
+        let mut auto_started = DOCKER_AUTO_STARTED.lock().unwrap();
+        *auto_started = false;
+        return Err(err.to_string());
     }
 
     Ok("starting".to_string())

--- a/packages/app/src/lib/composables/usePackageDeleter.svelte.ts
+++ b/packages/app/src/lib/composables/usePackageDeleter.svelte.ts
@@ -19,6 +19,20 @@ export function usePackageDeleter() {
       return false;
     }
 
+    const status = packagesStore.installationStatus(packageName);
+
+    if (status === "unknown") {
+      notifyError(
+        "Package status is still loading. Try again once it finishes.",
+      );
+      return false;
+    }
+
+    if (status !== "installed") {
+      notifyError(`${packageName} is not currently installed`);
+      return false;
+    }
+
     if (deletingPackages.has(packageName)) {
       return false;
     }

--- a/packages/app/src/lib/composables/usePackageInstaller.svelte.ts
+++ b/packages/app/src/lib/composables/usePackageInstaller.svelte.ts
@@ -15,6 +15,20 @@ export function usePackageInstaller() {
       return false;
     }
 
+    const status = packagesStore.installationStatus(packageName);
+
+    if (status === "unknown") {
+      notifyError(
+        "Package status is still loading. Try again once it finishes.",
+      );
+      return false;
+    }
+
+    if (status === "installed") {
+      notifyError(`${packageName} is already installed`);
+      return false;
+    }
+
     if (installingPackages.has(packageName)) {
       return false;
     }

--- a/packages/app/src/routes/+layout.svelte
+++ b/packages/app/src/routes/+layout.svelte
@@ -24,11 +24,21 @@ import {
   Users,
 } from "@lucide/svelte";
 import { packagesStore } from "$stores/packages.svelte";
+import { dockerStatus } from "$stores/dockerStatus.svelte";
 import { page } from "$app/state";
 
 const { children } = $props();
 
 const currentPath = $derived(page.url?.pathname || "");
+
+const installedState = $derived(packagesStore.installedState);
+const installedNodes = $derived(
+  installedState.status === "ready" ? packagesStore.installedPackages : [],
+);
+
+$effect(() => {
+  packagesStore.handleDockerStateChange(dockerStatus.isRunning);
+});
 
 const navigationItems = [
   { icon: House, label: "Dashboard", href: "/" },
@@ -119,11 +129,11 @@ onMount(async () => {
           </Sidebar.Menu>
         </Sidebar.Group>
 
-        {#if packagesStore.installedPackages.length > 0}
+        {#if installedState.status === "ready" && installedNodes.length > 0}
           <Sidebar.Group class="px-2 py-2 md:p-2">
             <Sidebar.GroupLabel>Installed Nodes</Sidebar.GroupLabel>
             <Sidebar.Menu>
-              {#each packagesStore.installedPackages as pkg}
+              {#each installedNodes as pkg}
                 <Sidebar.MenuItem>
                   <Sidebar.MenuButton
                     isActive={currentPath.startsWith(`/node/${pkg.name}`)}

--- a/packages/app/src/stores/packages.svelte.ts
+++ b/packages/app/src/stores/packages.svelte.ts
@@ -1,47 +1,164 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Package } from "$lib/types";
+import { dockerStatus } from "./dockerStatus.svelte";
 import { serverUrlStore } from "./serverUrl.svelte";
 
-let packages = $state<{ [name: string]: Package }>({});
-let installedPackages = $state<Package[]>([]);
-let isLoading = $state(false);
+type CatalogStatus = "idle" | "loading" | "ready" | "error";
+type InstalledStatus = "idle" | "loading" | "ready" | "unavailable" | "error";
+
+type CatalogState = {
+  status: CatalogStatus;
+  packages: Record<string, Package>;
+  error?: string;
+};
+
+type InstalledState = {
+  status: InstalledStatus;
+  packages: Record<string, Package>;
+  error?: string;
+};
+
+let catalogState = $state<CatalogState>({
+  status: "idle",
+  packages: {},
+});
+
+let installedState = $state<InstalledState>({
+  status: "idle",
+  packages: {},
+});
+
+let installedRequestToken = 0;
+
+function toPackageRecord(list: Package[]): Record<string, Package> {
+  return Object.fromEntries(list.map((pkg) => [pkg.name, pkg]));
+}
+
+function setInstalledUnavailable() {
+  installedRequestToken += 1;
+  installedState = {
+    status: "unavailable",
+    packages: {},
+  };
+}
+
+let lastDockerRunning: boolean | null = null;
 
 export const packagesStore = {
   get packages() {
-    return packages;
+    return catalogState.packages;
   },
 
-  get installedPackages() {
-    return installedPackages;
+  get catalogState() {
+    return catalogState;
   },
 
-  get isLoading() {
-    return isLoading;
+  get installedState() {
+    return installedState;
+  },
+
+  get installedPackages(): Package[] {
+    if (installedState.status !== "ready") {
+      return [];
+    }
+    return Object.values(installedState.packages);
+  },
+
+  installationStatus(
+    packageName: string | undefined,
+  ): "unknown" | "installed" | "available" {
+    if (!packageName) return "unknown";
+    if (installedState.status !== "ready") {
+      return "unknown";
+    }
+    return installedState.packages[packageName] ? "installed" : "available";
   },
 
   isInstalled(packageName: string | undefined): boolean {
     if (!packageName) return false;
-    return installedPackages.some((p) => p.name === packageName);
+    return Boolean(installedState.packages[packageName]);
   },
 
-  async loadPackages() {
+  async loadPackages({ force = false }: { force?: boolean } = {}) {
+    if (!force && catalogState.status === "loading") {
+      return;
+    }
+
+    if (!force && catalogState.status === "ready") {
+      return;
+    }
+
+    const previous = catalogState.packages;
+    catalogState = {
+      status: "loading",
+      packages: force ? {} : { ...previous },
+    };
+
     try {
-      packages = await invoke("get_packages");
+      const result = await invoke<Record<string, Package>>("get_packages");
+      catalogState = {
+        status: "ready",
+        packages: result,
+      };
     } catch (e) {
       console.error(`Failed to load packages: ${e}`);
+      catalogState = {
+        status: "error",
+        packages: {},
+        error: e instanceof Error ? e.message : String(e),
+      };
     }
   },
 
-  async loadInstalledPackages() {
-    isLoading = true;
+  async loadInstalledPackages({ force = false }: { force?: boolean } = {}) {
+    const running = dockerStatus.isRunning;
+
+    if (running === false) {
+      setInstalledUnavailable();
+      return;
+    }
+
+    if (running !== true) {
+      return;
+    }
+
+    if (!force && installedState.status === "loading") {
+      return;
+    }
+
+    const requestId = ++installedRequestToken;
+    const previous = installedState.packages;
+    installedState = {
+      status: "loading",
+      packages: force ? {} : { ...previous },
+    };
+
     try {
-      installedPackages = await invoke("get_installed_packages", {
+      const result = await invoke<Package[]>("get_installed_packages", {
         serverUrl: serverUrlStore.serverUrl,
       });
+
+      if (requestId !== installedRequestToken) {
+        return;
+      }
+
+      const packages = toPackageRecord(result);
+      installedState = {
+        status: "ready",
+        packages,
+      };
     } catch (e) {
-      console.error(`Failed to load installed packages: ${e}`);
-    } finally {
-      isLoading = false;
+      if (requestId !== installedRequestToken) {
+        return;
+      }
+
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(`Failed to load installed packages: ${message}`);
+      installedState = {
+        status: dockerStatus.isRunning === true ? "error" : "unavailable",
+        packages: {},
+        error: message,
+      };
     }
   },
 
@@ -51,7 +168,7 @@ export const packagesStore = {
         name,
         serverUrl: serverUrlStore.serverUrl,
       });
-      await this.loadInstalledPackages();
+      await this.loadInstalledPackages({ force: true });
     } catch (e) {
       console.error(`Failed to install ${name}: ${e}`);
       throw e;
@@ -65,10 +182,27 @@ export const packagesStore = {
         includeImages: false,
         serverUrl: serverUrlStore.serverUrl,
       });
-      await this.loadInstalledPackages();
+      await this.loadInstalledPackages({ force: true });
     } catch (e) {
       console.error(`Failed to delete ${name}: ${e}`);
       throw e;
+    }
+  },
+
+  handleDockerStateChange(running: boolean | null) {
+    if (running === lastDockerRunning) {
+      return;
+    }
+
+    lastDockerRunning = running;
+
+    if (running === true) {
+      void this.loadInstalledPackages({ force: true });
+      return;
+    }
+
+    if (running === false) {
+      setInstalledUnavailable();
     }
   },
 };


### PR DESCRIPTION
## Summary
- ensure we only auto-start Docker once per app session and roll back on failure
- refactor package state management to derive installed availability from a single source of truth
- update dashboard, package store, and node views to surface loading/unavailable states and block invalid actions

## Testing
- just lint-js
- just lint-rs
