### PR TITLE
Respect Docker intent when containers stop

### DIFF
--- a/packages/app/src/lib/composables/usePackageDeleter.svelte.ts
+++ b/packages/app/src/lib/composables/usePackageDeleter.svelte.ts
@@ -19,6 +19,20 @@ export function usePackageDeleter() {
       return false;
     }
 
+    const status = packagesStore.installationStatus(packageName);
+
+    if (status === "unknown") {
+      notifyError(
+        "Package status is still loading. Try again once it finishes.",
+      );
+      return false;
+    }
+
+    if (status !== "running" && status !== "stopped") {
+      notifyError(`${packageName} is not currently installed`);
+      return false;
+    }
+
     if (deletingPackages.has(packageName)) {
       return false;
     }

--- a/packages/app/src/lib/composables/usePackageInstaller.svelte.ts
+++ b/packages/app/src/lib/composables/usePackageInstaller.svelte.ts
@@ -15,6 +15,27 @@ export function usePackageInstaller() {
       return false;
     }
 
+    const status = packagesStore.installationStatus(packageName);
+
+    if (status === "unknown") {
+      notifyError(
+        "Package status is still loading. Try again once it finishes.",
+      );
+      return false;
+    }
+
+    if (status === "running") {
+      notifyError(`${packageName} is already installed and running`);
+      return false;
+    }
+
+    if (status === "stopped") {
+      notifyError(
+        `${packageName} is installed but stopped. Start the containers in Docker Desktop or delete the package before reinstalling.`,
+      );
+      return false;
+    }
+
     if (installingPackages.has(packageName)) {
       return false;
     }

--- a/packages/app/src/lib/types/package.ts
+++ b/packages/app/src/lib/types/package.ts
@@ -5,6 +5,16 @@ export interface Package {
   containers: Container[];
 }
 
+export interface InstalledPackage {
+  package: Package;
+  isRunning: boolean;
+}
+
+export interface InstalledPackageApi {
+  package: Package;
+  is_running: boolean;
+}
+
 export interface Container {
   name: string;
   image: string;

--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -23,6 +23,38 @@ import {
 
 const { isInstalling, installPackage } = usePackageInstaller();
 
+const catalogState = $derived(packagesStore.catalogState);
+const installedState = $derived(packagesStore.installedState);
+
+const totalPackageCount = $derived(
+  catalogState.status === "ready"
+    ? Object.keys(packagesStore.packages).length
+    : null,
+);
+
+const installedPackages = $derived(
+  installedState.status === "ready" ? packagesStore.installedPackages : [],
+);
+
+const runningNodes = $derived(
+  installedPackages.filter((entry) => entry.isRunning),
+);
+const stoppedNodes = $derived(
+  installedPackages.filter((entry) => !entry.isRunning),
+);
+
+const installedPackageCount = $derived(
+  installedState.status === "ready" ? runningNodes.length : null,
+);
+
+const featuredAvailablePackages = $derived(
+  catalogState.status !== "ready" || installedState.status !== "ready"
+    ? null
+    : Object.entries(catalogState.packages)
+        .filter(([name]) => !Object.hasOwn(installedState.packages, name))
+        .slice(0, 3),
+);
+
 function managePackage(packageName: string) {
   goto(`/node/${packageName}`);
 }
@@ -32,8 +64,6 @@ function isMobileAndLocal() {
     ["ios", "android"].includes(platform()) && serverUrlStore.serverUrl === ""
   );
 }
-
-// Removed unused helpers to keep file tidy
 
 onMount(async () => {
   if (!systemInfoStore.systemInfo) systemInfoStore.fetchSystemInfo();
@@ -78,12 +108,12 @@ onDestroy(() => {
           <Package2 class="h-4 w-4 text-muted-foreground" />
         </Card.Title>
       </Card.Header>
-      <Card.Content>
+        <Card.Content>
         <div class="text-2xl font-bold">
-          {packagesStore.installedPackages.length}
+          {installedPackageCount ?? "--"}
         </div>
         <p class="text-xs text-muted-foreground">
-          of {Object.keys(packagesStore.packages).length} available
+          of {totalPackageCount ?? "--"} available
         </p>
       </Card.Content>
     </Card.Root>
@@ -125,11 +155,38 @@ onDestroy(() => {
     {/if}
   </div>
 
-  {#if packagesStore.installedPackages.length > 0}
-    <div class="space-y-4">
-      <h3 class="text-xl font-semibold">Running Nodes</h3>
+  <div class="space-y-4">
+    <h3 class="text-xl font-semibold">Running Nodes</h3>
+
+    {#if installedState.status === "loading" || installedState.status === "idle"}
+      <Card.Root>
+        <Card.Content>
+          <p class="text-sm text-muted-foreground">Checking installed packages...</p>
+        </Card.Content>
+      </Card.Root>
+    {:else if installedState.status === "unavailable"}
+      <Card.Root>
+        <Card.Content>
+          <p class="text-sm text-muted-foreground">
+            Docker needs to be running to manage installed nodes. Start Docker Desktop to continue.
+          </p>
+        </Card.Content>
+      </Card.Root>
+    {:else if installedState.status === "error"}
+      <Card.Root>
+        <Card.Content class="flex items-center justify-between">
+          <p class="text-sm text-muted-foreground">
+            Failed to load installed packages.
+          </p>
+          <Button size="sm" variant="outline" onclick={() => packagesStore.loadInstalledPackages({ force: true })}>
+            Retry
+          </Button>
+        </Card.Content>
+      </Card.Root>
+    {:else if runningNodes.length > 0}
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {#each packagesStore.installedPackages as pkg}
+        {#each runningNodes as entry}
+          {@const pkg = entry.package}
           <Card.Root>
             <Card.Header>
               <div class="flex items-start justify-between">
@@ -164,6 +221,59 @@ onDestroy(() => {
           </Card.Root>
         {/each}
       </div>
+    {:else}
+      <Card.Root>
+        <Card.Content>
+          <p class="text-sm text-muted-foreground">No nodes currently running.</p>
+        </Card.Content>
+      </Card.Root>
+    {/if}
+  </div>
+
+  {#if stoppedNodes.length > 0}
+    <div class="space-y-4">
+      <h3 class="text-xl font-semibold">Stopped Nodes</h3>
+      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {#each stoppedNodes as entry}
+          {@const pkg = entry.package}
+          <Card.Root>
+            <Card.Header>
+              <div class="flex items-start justify-between">
+                <div class="flex items-start gap-3">
+                  <div class="shrink-0">
+                    <Activity class="w-5 h-5 text-yellow-500 mt-0.5" />
+                  </div>
+                  <div class="min-w-0">
+                    <Card.Title class="text-base">{pkg.name}</Card.Title>
+                    <Card.Description class="mt-1">
+                      {pkg.description}
+                    </Card.Description>
+                  </div>
+                </div>
+                <div class="flex items-center space-x-1 rounded-full bg-yellow-500/10 px-2 py-1 shrink-0">
+                  <div class="h-2 w-2 rounded-full bg-yellow-500"></div>
+                  <span class="text-xs font-medium text-yellow-700 dark:text-yellow-400">Stopped</span>
+                </div>
+              </div>
+            </Card.Header>
+            <Card.Content>
+              <p class="text-sm text-muted-foreground">
+                Start the containers in Docker Desktop or delete and reinstall this node.
+              </p>
+            </Card.Content>
+            <Card.Footer>
+              <Button
+                size="sm"
+                variant="outline"
+                onclick={() => managePackage(pkg.name)}
+                class="w-full"
+              >
+                View Details
+              </Button>
+            </Card.Footer>
+          </Card.Root>
+        {/each}
+      </div>
     </div>
   {/if}
 
@@ -180,58 +290,25 @@ onDestroy(() => {
       </Button>
     </div>
 
-    {#if Object.keys(packagesStore.packages).length > 0}
-      {@const availablePackages = Object.entries(packagesStore.packages)
-        .filter(([name]) => !packagesStore.isInstalled(name))
-        .slice(0, 3)}
-
-      {#if availablePackages.length > 0}
-        <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {#each availablePackages as [name, pkg]}
-            {@const isInstallingPackage = isInstalling(name)}
-            <Card.Root>
-              <Card.Header>
-                <div class="flex items-start gap-3">
-                  <div class="shrink-0">
-                    <Package2 class="w-5 h-5 text-muted-foreground mt-0.5" />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <Card.Title class="text-base">{name}</Card.Title>
-                    <Card.Description class="mt-1">
-                      {pkg.description}
-                    </Card.Description>
-                  </div>
-                </div>
-              </Card.Header>
-
-              <Card.Footer>
-                <Button
-                  size="sm"
-                  variant="default"
-                  onclick={() => installPackage(name)}
-                  disabled={!dockerStatus.isRunning || isInstallingPackage}
-                  class="w-full"
-                >
-                  {#if isInstallingPackage}
-                    <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
-                    Installing...
-                  {:else}
-                    <Download class="h-4 w-4 mr-1" />
-                    Install
-                  {/if}
-                </Button>
-              </Card.Footer>
-            </Card.Root>
-          {/each}
-        </div>
-      {:else}
-        <Card.Root>
-          <Card.Content>
-            <p class="text-center text-muted-foreground">All available packages are installed!</p>
-          </Card.Content>
-        </Card.Root>
-      {/if}
-    {:else if !dockerStatus.isRunning}
+    {#if catalogState.status === "error"}
+      <Card.Root>
+        <Card.Content class="flex items-center justify-between">
+          <p class="text-sm text-muted-foreground">Failed to load available packages.</p>
+          <Button size="sm" variant="outline" onclick={() => packagesStore.loadPackages({ force: true })}>
+            Retry
+          </Button>
+        </Card.Content>
+      </Card.Root>
+    {:else if installedState.status === "error"}
+      <Card.Root>
+        <Card.Content class="flex items-center justify-between">
+          <p class="text-sm text-muted-foreground">Failed to confirm installed packages.</p>
+          <Button size="sm" variant="outline" onclick={() => packagesStore.loadInstalledPackages({ force: true })}>
+            Retry
+          </Button>
+        </Card.Content>
+      </Card.Root>
+    {:else if installedState.status === "unavailable"}
       <Card.Root>
         <Card.Header>
           <Card.Title class="flex items-center space-x-2">
@@ -241,14 +318,63 @@ onDestroy(() => {
         </Card.Header>
         <Card.Content>
           <p class="text-sm text-muted-foreground">
-            Docker needs to be running to view and manage packages. Please start Docker Desktop and refresh this page.
+            Docker needs to be running to view and manage packages. Please start Docker Desktop and return to this page.
           </p>
         </Card.Content>
       </Card.Root>
+    {:else if catalogState.status !== "ready" || installedState.status !== "ready"}
+      <Card.Root>
+        <Card.Content>
+          <p class="text-sm text-muted-foreground">Loading packages...</p>
+        </Card.Content>
+      </Card.Root>
+    {:else if featuredAvailablePackages && featuredAvailablePackages.length > 0}
+      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {#each featuredAvailablePackages as [name, pkg]}
+          {@const status = packagesStore.installationStatus(name)}
+          {@const isInstallingPackage = isInstalling(name)}
+          {@const disabled =
+            dockerStatus.isRunning !== true || status !== "available" || isInstallingPackage}
+
+          <Card.Root>
+            <Card.Header>
+              <div class="flex items-start gap-3">
+                <div class="shrink-0">
+                  <Package2 class="w-5 h-5 text-muted-foreground mt-0.5" />
+                </div>
+                <div class="min-w-0 flex-1">
+                  <Card.Title class="text-base">{name}</Card.Title>
+                  <Card.Description class="mt-1">
+                    {pkg.description}
+                  </Card.Description>
+                </div>
+              </div>
+            </Card.Header>
+
+            <Card.Footer>
+              <Button
+                size="sm"
+                variant="default"
+                onclick={() => installPackage(name)}
+                disabled={disabled}
+                class="w-full"
+              >
+                {#if isInstallingPackage}
+                  <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                  Installing...
+                {:else}
+                  <Download class="h-4 w-4 mr-1" />
+                  Install
+                {/if}
+              </Button>
+            </Card.Footer>
+          </Card.Root>
+        {/each}
+      </div>
     {:else}
       <Card.Root>
         <Card.Content>
-          <p class="text-center text-muted-foreground">No packages available.</p>
+          <p class="text-center text-muted-foreground">All available packages are installed!</p>
         </Card.Content>
       </Card.Root>
     {/if}

--- a/packages/app/src/routes/packages/+page.svelte
+++ b/packages/app/src/routes/packages/+page.svelte
@@ -19,7 +19,14 @@ const { isInstalling, installPackage } = usePackageInstaller();
 
 let searchQuery = $state("");
 
+const catalogState = $derived(packagesStore.catalogState);
+const installedState = $derived(packagesStore.installedState);
+
 const filteredPackages = $derived(() => {
+  if (catalogState.status !== "ready") {
+    return [];
+  }
+
   const query = searchQuery.toLowerCase();
   return Object.entries(packagesStore.packages)
     .filter(
@@ -53,7 +60,35 @@ onMount(() => {
     </p>
   </div>
 
-  {#if !dockerStatus.isRunning}
+  <div class="relative">
+    <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+    <input
+      type="text"
+      placeholder="Search packages..."
+      bind:value={searchQuery}
+      class="w-full rounded-md border bg-background pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+    />
+  </div>
+
+  {#if catalogState.status === "error"}
+    <Card.Root>
+      <Card.Content class="flex items-center justify-between">
+        <p class="text-sm text-muted-foreground">Failed to load packages.</p>
+        <Button size="sm" variant="outline" onclick={() => packagesStore.loadPackages({ force: true })}>
+          Retry
+        </Button>
+      </Card.Content>
+    </Card.Root>
+  {:else if installedState.status === "error"}
+    <Card.Root>
+      <Card.Content class="flex items-center justify-between">
+        <p class="text-sm text-muted-foreground">Failed to confirm installed packages.</p>
+        <Button size="sm" variant="outline" onclick={() => packagesStore.loadInstalledPackages({ force: true })}>
+          Retry
+        </Button>
+      </Card.Content>
+    </Card.Root>
+  {:else if installedState.status === "unavailable"}
     <Card.Root class="border-yellow-500/50 bg-yellow-500/10">
       <Card.Header>
         <Card.Title class="flex items-center space-x-2">
@@ -67,22 +102,16 @@ onMount(() => {
         </p>
       </Card.Content>
     </Card.Root>
-  {/if}
-
-  <div class="relative">
-    <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-    <input
-      type="text"
-      placeholder="Search packages..."
-      bind:value={searchQuery}
-      class="w-full rounded-md border bg-background pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-    />
-  </div>
-
-  {#if filteredPackages().length > 0}
+  {:else if catalogState.status !== "ready" || installedState.status === "loading" || installedState.status === "idle"}
+    <Card.Root>
+      <Card.Content>
+        <p class="text-sm text-muted-foreground">Loading packages...</p>
+      </Card.Content>
+    </Card.Root>
+  {:else if filteredPackages().length > 0}
     <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {#each filteredPackages() as [name, pkg]}
-        {@const isInstalled = packagesStore.isInstalled(name)}
+        {@const status = packagesStore.installationStatus(name)}
         {@const isInstallingPackage = isInstalling(name)}
 
         <Card.Root>
@@ -97,17 +126,22 @@ onMount(() => {
                   </Card.Description>
                 </div>
               </div>
-              {#if isInstalled}
+              {#if status === "running"}
                 <div class="flex items-center space-x-1 rounded-full bg-green-500/10 px-2 py-1">
                   <CircleCheck class="h-3 w-3 text-green-500" />
                   <span class="text-xs font-medium text-green-700 dark:text-green-400">Installed</span>
+                </div>
+              {:else if status === "stopped"}
+                <div class="flex items-center space-x-1 rounded-full bg-yellow-500/10 px-2 py-1">
+                  <CircleAlert class="h-3 w-3 text-yellow-500" />
+                  <span class="text-xs font-medium text-yellow-700 dark:text-yellow-400">Stopped</span>
                 </div>
               {/if}
             </div>
           </Card.Header>
 
           <Card.Footer>
-            {#if isInstalled}
+            {#if status === "running"}
               <Button
                 size="sm"
                 variant="default"
@@ -117,12 +151,22 @@ onMount(() => {
                 <Settings2 class="h-4 w-4 mr-1" />
                 Manage
               </Button>
-            {:else}
+            {:else if status === "stopped"}
+              <Button
+                size="sm"
+                variant="outline"
+                onclick={() => managePackage(name)}
+                class="w-full"
+              >
+                <Settings2 class="h-4 w-4 mr-1" />
+                View Details
+              </Button>
+            {:else if status === "available"}
               <Button
                 size="sm"
                 variant="default"
                 onclick={() => installPackage(name)}
-                disabled={!dockerStatus.isRunning || isInstallingPackage}
+                disabled={dockerStatus.isRunning !== true || isInstallingPackage}
                 class="w-full"
               >
                 {#if isInstallingPackage}
@@ -132,6 +176,10 @@ onMount(() => {
                   <Download class="h-4 w-4 mr-1" />
                   Install
                 {/if}
+              </Button>
+            {:else}
+              <Button size="sm" variant="outline" disabled class="w-full">
+                Checking status...
               </Button>
             {/if}
           </Card.Footer>

--- a/packages/core/src/application/get_installed_packages.rs
+++ b/packages/core/src/application/get_installed_packages.rs
@@ -1,11 +1,11 @@
 use crate::{
-    domain::package::Package,
+    domain::package::InstalledPackage,
     infra::package::{self, get_packages},
 };
 use eyre::{Context, Result};
 use tracing::info;
 
-pub async fn get_installed_packages() -> Result<Vec<Package>> {
+pub async fn get_installed_packages() -> Result<Vec<InstalledPackage>> {
     let packages = get_packages().wrap_err("Failed to retrieve packages")?;
     let installed = package::get_installed_packages(&packages).await?;
     info!("Found {} installed packages", installed.len());

--- a/packages/core/src/domain/package.rs
+++ b/packages/core/src/domain/package.rs
@@ -32,6 +32,12 @@ pub struct Package {
     pub(crate) default_config: PackageConfig,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct InstalledPackage {
+    pub package: Package,
+    pub is_running: bool,
+}
+
 impl fmt::Display for Package {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Package: {}", self.name)?;

--- a/packages/web/src/main.rs
+++ b/packages/web/src/main.rs
@@ -6,7 +6,7 @@ use axum::{
     routing::{get, post},
 };
 use kittynode_core::domain::logs::LogsQuery;
-use kittynode_core::domain::package::Package;
+use kittynode_core::domain::package::InstalledPackage;
 use kittynode_core::domain::system_info::SystemInfo;
 
 pub(crate) async fn hello_world() -> &'static str {
@@ -53,7 +53,8 @@ pub(crate) async fn delete_package(
     Ok(StatusCode::OK)
 }
 
-pub(crate) async fn get_installed_packages() -> Result<Json<Vec<Package>>, (StatusCode, String)> {
+pub(crate) async fn get_installed_packages()
+-> Result<Json<Vec<InstalledPackage>>, (StatusCode, String)> {
     kittynode_core::application::get_installed_packages()
         .await
         .map(Json)


### PR DESCRIPTION
## Summary
- report per-package runtime state from the backend so stopped containers no longer look healthy
- simplify Svelte stores to track running vs stopped nodes and avoid aggressive polling loops
- update UI states to surface stopped nodes, disable manage buttons, and guide users to restart or reinstall

## Testing
- just lint-js
- just lint-rs
