### PR TITLE
Ensure manage view doesn't overflow at mid widths

### DIFF
--- a/packages/app/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/packages/app/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -14,7 +14,7 @@ let {
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		"bg-background relative flex w-full flex-1 flex-col",
+		"bg-background relative flex w-full min-w-0 flex-1 flex-col",
 		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 		className
 	)}


### PR DESCRIPTION
## Summary
- add min-w-0 to the sidebar inset so content can shrink with the sidebar

## Testing
- just lint-js