### PR TITLE
Fix Docker detection on Linux

### DIFF
--- a/packages/core/src/application/get_container_logs.rs
+++ b/packages/core/src/application/get_container_logs.rs
@@ -5,6 +5,6 @@ pub async fn get_container_logs(
     container_name: &str,
     tail_lines: Option<usize>,
 ) -> Result<Vec<String>> {
-    let docker = get_docker_instance()?;
+    let docker = get_docker_instance().await?;
     crate::infra::docker::get_container_logs(&docker, container_name, tail_lines).await
 }

--- a/packages/core/src/application/is_docker_running.rs
+++ b/packages/core/src/application/is_docker_running.rs
@@ -1,10 +1,12 @@
 use crate::infra::docker::get_docker_instance;
+use tracing::warn;
 
 pub async fn is_docker_running() -> bool {
-    match get_docker_instance() {
-        Ok(connection) => connection.version().await.is_ok(),
-        _ => {
-            false // Docker connection failed
+    match get_docker_instance().await {
+        Ok(_) => true,
+        Err(err) => {
+            warn!("Docker not reachable: {}", err);
+            false
         }
     }
 }

--- a/packages/core/src/infra/package.rs
+++ b/packages/core/src/infra/package.rs
@@ -20,7 +20,7 @@ pub fn get_packages() -> Result<HashMap<String, Package>> {
 
 /// Gets a list of installed packages by checking their container states
 pub async fn get_installed_packages(packages: &HashMap<String, Package>) -> Result<Vec<Package>> {
-    let docker = get_docker_instance()?;
+    let docker = get_docker_instance().await?;
     let mut installed = Vec::new();
 
     for package in packages.values() {
@@ -44,7 +44,7 @@ pub async fn get_installed_packages(packages: &HashMap<String, Package>) -> Resu
 
 /// Installs a package with the given network configuration
 pub async fn install_package(package: &Package, network: Option<&str>) -> Result<()> {
-    let docker = get_docker_instance()?;
+    let docker = get_docker_instance().await?;
     let containers = match package.name.as_str() {
         "Ethereum" => Ethereum::get_containers(network.unwrap_or("holesky"))?,
         _ => package.containers.clone(),
@@ -64,7 +64,7 @@ pub async fn install_package(package: &Package, network: Option<&str>) -> Result
 
 /// Deletes a package and its associated resources
 pub async fn delete_package(package: &Package, include_images: bool) -> Result<()> {
-    let docker = get_docker_instance()?;
+    let docker = get_docker_instance().await?;
 
     // Clean up containers and collect resources to remove
     let mut image_names = Vec::new();


### PR DESCRIPTION
## Summary
- ensure we probe Docker Desktop's user sockets on Linux when /var/run/docker.sock isn't accessible
- use the async connector everywhere so installed packages and logs share the same discovery logic

## Testing
- just lint-rs
- just test